### PR TITLE
Implement logging with tinylog

### DIFF
--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -7,7 +7,7 @@ import Data.Maybe (fromMaybe)
 import Nanocoin (initNode)
 
 import Options.Applicative
-import Logger hiding (info)
+import Logger
 
 data Config = Config
   { rpcPort      :: Int
@@ -20,7 +20,7 @@ defaultConfig = Config 3000 Nothing
 main :: IO ()
 main = do
     Config rpc mKeys <- execParser (info parser mempty)
-    logger <- create StdOut
+    logger <- Logger.create Logger.StdOut
     initNode rpc mKeys logger
   where
     portParser :: Parser (Maybe Int)

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -7,6 +7,7 @@ import Data.Maybe (fromMaybe)
 import Nanocoin (initNode)
 
 import Options.Applicative
+import Logger
 
 data Config = Config
   { rpcPort      :: Int
@@ -19,7 +20,8 @@ defaultConfig = Config 3000 Nothing
 main :: IO ()
 main = do
     Config rpc mKeys <- execParser (info parser mempty)
-    initNode rpc mKeys
+    logger <- create StdOut
+    initNode rpc mKeys logger
   where
     portParser :: Parser (Maybe Int)
     portParser = optional $

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -7,7 +7,7 @@ import Data.Maybe (fromMaybe)
 import Nanocoin (initNode)
 
 import Options.Applicative
-import Logger
+import Logger hiding (info)
 
 data Config = Config
   { rpcPort      :: Int

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -20,7 +20,7 @@ defaultConfig = Config 3000 Nothing
 main :: IO ()
 main = do
     Config rpc mKeys <- execParser (info parser mempty)
-    logger <- Logger.create Logger.StdOut
+    logger <- Logger.create (Logger.Path "nanocoin.log")
     initNode rpc mKeys logger
   where
     portParser :: Parser (Maybe Int)

--- a/nanocoin.cabal
+++ b/nanocoin.cabal
@@ -26,7 +26,8 @@ library
 
                      Address,
                      Hash,
-                     Key
+                     Key,
+                     Logger
 
   build-depends:
     base              >= 4.6    && <5.0,

--- a/nanocoin.cabal
+++ b/nanocoin.cabal
@@ -16,65 +16,67 @@ library
                      Nanocoin.Ledger,
                      Nanocoin.MemPool,
                      Nanocoin.Transaction,
-                     
+
                      Nanocoin.Network.Multicast,
                      Nanocoin.Network.Message,
                      Nanocoin.Network.Node,
                      Nanocoin.Network.P2P,
                      Nanocoin.Network.Peer,
                      Nanocoin.Network.RPC,
-                     
+
                      Address,
                      Hash,
                      Key
 
-  build-depends:      
+  build-depends:
     base              >= 4.6    && <5.0,
     transformers      >= 0.4    && <0.6,
     containers        >= 0.4    && <0.6,
     time              >= 1.6    && <1.7,
     memory            >= 0.14   && <0.15,
     protolude         >= 0.2,
-   
+
     aeson             >= 1.0    && <1.2,
     cereal            >= 0.5    && <0.6,
     bytestring        >= 0.10   && <0.11,
     base58-bytestring >= 0.0.3  && <1.0,
     base64-bytestring >= 1.0    && <1.1,
     text              >= 1.2    && <1.3,
-    
+
     cryptonite        >= 0.20   && <0.30,
     merkle-tree       >= 0.1.0   && <0.2.0,
-   
+
     haskeline         >= 0.7.4,
 
     scotty            >= 0.11   && <0.12,
-    
+
     network           >= 2.6    && <2.7,
     network-multicast >= 0.2    && <0.3,
     network-transport >= 0.4    && <0.5,
-    
+
     directory         >= 1.3    && <1.4,
-    filepath          >= 1.4.1.1 && <1.5.0.0
-    
+    filepath          >= 1.4.1.1 && <1.5.0.0,
+
+    tinylog           >= 0.14.0 && <0.15.0
+
 
   default-language:   Haskell2010
-  default-extensions: OverloadedStrings NoImplicitPrelude 
+  default-extensions: OverloadedStrings NoImplicitPrelude
   hs-source-dirs:     src
   ghc-options:
     -Werror
     -fno-warn-type-defaults
 
-executable nanocoin 
+executable nanocoin
   hs-source-dirs:     exe
   main-is:            Main.hs
   ghc-options:        -threaded -rtsopts -with-rtsopts=-N
   build-depends:      base
-                    , nanocoin 
+                    , nanocoin
                     , optparse-applicative
                     , protolude
   default-language:   Haskell2010
-  default-extensions: OverloadedStrings NoImplicitPrelude 
+  default-extensions: OverloadedStrings NoImplicitPrelude
   ghc-options:
     -Wall
     -Werror

--- a/src/Logger.hs
+++ b/src/Logger.hs
@@ -2,12 +2,9 @@
 module Logger (
   Level(..),
   Output(..),
-  Logger(..),
   create,
   print,
   putText,
-  info,
-  msg,
   MonadLogger(..)
 ) where
 

--- a/src/Logger.hs
+++ b/src/Logger.hs
@@ -4,9 +4,12 @@ module Logger (
   Output(..),
   Logger(..),
   create,
+  print,
+  putText,
   MonadLogger(..)
 ) where
 
+import Protolude hiding (print, putText, ask)
 import System.Logger.Class
 import qualified System.Logger as Logger
 import Control.Monad.IO.Class
@@ -16,3 +19,9 @@ instance MonadIO m => MonadLogger (ReaderT Logger m) where
   log lvl f = do
     logger <- ask
     Logger.log logger lvl f
+
+print :: (MonadLogger m, Show a) => a -> m ()
+print = info . msg .(show :: Show a => a -> Text)
+
+putText :: MonadLogger m => Text -> m ()
+putText = info . msg

--- a/src/Logger.hs
+++ b/src/Logger.hs
@@ -1,0 +1,12 @@
+{-# LANGUAGE FlexibleInstances #-}
+module Logger () where
+
+import System.Logger.Class
+import qualified System.Logger as Logger
+import Control.Monad.IO.Class
+import Control.Monad.Trans.Reader
+
+instance MonadIO m => MonadLogger (ReaderT Logger m) where
+  log lvl f = do
+    logger <- ask
+    Logger.log logger lvl f

--- a/src/Logger.hs
+++ b/src/Logger.hs
@@ -1,5 +1,11 @@
 {-# LANGUAGE FlexibleInstances #-}
-module Logger () where
+module Logger (
+  Level(..),
+  Output(..),
+  Logger(..),
+  create,
+  MonadLogger(..)
+) where
 
 import System.Logger.Class
 import qualified System.Logger as Logger

--- a/src/Logger.hs
+++ b/src/Logger.hs
@@ -6,6 +6,8 @@ module Logger (
   create,
   print,
   putText,
+  info,
+  msg,
   MonadLogger(..)
 ) where
 
@@ -20,8 +22,8 @@ instance MonadIO m => MonadLogger (ReaderT Logger m) where
     logger <- ask
     Logger.log logger lvl f
 
-print :: (MonadLogger m, Show a) => a -> m ()
+print :: (MonadLogger m, MonadIO m, Show a) => a -> m ()
 print = info . msg .(show :: Show a => a -> Text)
 
-putText :: MonadLogger m => Text -> m ()
+putText :: (MonadIO m, MonadLogger m) => Text -> m ()
 putText = info . msg

--- a/src/Nanocoin.hs
+++ b/src/Nanocoin.hs
@@ -10,6 +10,7 @@ import Protolude hiding (get, put)
 
 import Web.Scotty
 import Logger
+import qualified System.Logger as Logger
 
 import qualified Key
 import qualified Nanocoin.Block as B
@@ -23,7 +24,7 @@ import qualified Nanocoin.Network.RPC as RPC
 
 -- | Initializes a node on the network with it's own copy of
 -- the blockchain, and invokes a p2p server and an http server.
-initNode :: Int -> Maybe FilePath -> Logger -> IO ()
+initNode :: Int -> Maybe FilePath -> Logger.Logger -> IO ()
 initNode rpcPort mKeysPath logger = do
   let peer = Peer.mkPeer rpcPort
 

--- a/src/Nanocoin.hs
+++ b/src/Nanocoin.hs
@@ -48,12 +48,10 @@ initNode rpcPort mKeysPath logger = do
   nodeState <- Node.initNodeState peer genesisBlock keys
 
   -- Fork P2P server
-  -- todo: add logging
   forkIO $ P2P.p2p nodeState logger
   -- Join network by querying latest block
   joinNetwork $ Node.nodeSender nodeState
   -- Run RPC server
-  -- todo: add logging
   RPC.rpcServer nodeState logger
 
 -- | Query the network for the latest block

--- a/src/Nanocoin.hs
+++ b/src/Nanocoin.hs
@@ -9,6 +9,7 @@ module Nanocoin (
 import Protolude hiding (get, put)
 
 import Web.Scotty
+import Logger
 
 import qualified Key
 import qualified Nanocoin.Block as B
@@ -22,8 +23,8 @@ import qualified Nanocoin.Network.RPC as RPC
 
 -- | Initializes a node on the network with it's own copy of
 -- the blockchain, and invokes a p2p server and an http server.
-initNode :: Int -> Maybe FilePath -> IO ()
-initNode rpcPort mKeysPath = do
+initNode :: Int -> Maybe FilePath -> Logger -> IO ()
+initNode rpcPort mKeysPath logger = do
   let peer = Peer.mkPeer rpcPort
 
   -- Initialize Node Keys
@@ -46,11 +47,13 @@ initNode rpcPort mKeysPath = do
   nodeState <- Node.initNodeState peer genesisBlock keys
 
   -- Fork P2P server
-  forkIO $ P2P.p2p nodeState
+  -- todo: add logging
+  forkIO $ P2P.p2p nodeState logger
   -- Join network by querying latest block
   joinNetwork $ Node.nodeSender nodeState
   -- Run RPC server
-  RPC.rpcServer nodeState
+  -- todo: add logging
+  RPC.rpcServer nodeState logger
 
 -- | Query the network for the latest block
 joinNetwork :: Msg.MsgSender -> IO ()

--- a/src/Nanocoin/Network/Node.hs
+++ b/src/Nanocoin/Network/Node.hs
@@ -24,7 +24,9 @@ module Nanocoin.Network.Node (
 
 ) where
 
-import Protolude
+import Protolude hiding (print, putText)
+import Logger
+import qualified System.Logger as Logger
 
 import Control.Concurrent.MVar (MVar)
 import Data.Aeson (ToJSON(..))
@@ -107,7 +109,7 @@ setBlockChain :: MonadIO m => NodeState -> Blockchain -> m ()
 setBlockChain nodeState chain = modifyBlockChain_ nodeState (const chain)
 
 applyBlock
-  :: MonadIO m
+  :: (MonadIO m, MonadLogger m)
   => NodeState
   -> Block
   -> Block
@@ -133,7 +135,7 @@ applyBlock nodeState prevBlock  block = do
             T.unlines $ map ((<>) "\t" . show) itxs
 
 mineBlock
-  :: MonadIO m
+  :: (MonadIO m, MonadLogger m)
   => NodeState
   -> m (Either NodeStateError Block)
 mineBlock nodeState = do
@@ -177,10 +179,10 @@ mineBlock nodeState = do
            pure $ Left NoValidTxsInMemPool
 
 
-setLedger :: MonadIO m => NodeState -> Ledger.Ledger -> m ()
-setLedger nodeState ledger =
-  modifyNodeState_ nodeState nodeLedger $ \_ ->
-    putText "setLedger: Updating Ledger..." >> pure ledger
+setLedger :: (MonadIO m, MonadLogger m) => NodeState -> Ledger.Ledger -> m ()
+setLedger nodeState ledger = do
+  putText "setLedger: Updating Ledger..."
+  modifyNodeState_ nodeState nodeLedger $ \_ -> pure ledger
 
 modifyMemPool_
   :: MonadIO m
@@ -204,7 +206,7 @@ purgeMemPool nodeState = do
   return invalidTxErrs
 
 resetMemPool
-  :: MonadIO m
+  :: (MonadIO m, MonadLogger m)
   => NodeState
   -> m ()
 resetMemPool nodeState = do

--- a/src/Nanocoin/Network/P2P.hs
+++ b/src/Nanocoin/Network/P2P.hs
@@ -5,6 +5,7 @@ module Nanocoin.Network.P2P (
 ) where
 
 import Protolude hiding (msg)
+import Logger
 
 import Control.Arrow ((&&&))
 
@@ -25,8 +26,8 @@ import qualified Nanocoin.Network.RPC as RPC
 
 -- | Initializes a p2p node and returns a sender function so that
 -- the rpc server can broadcast messages to the p2p network
-p2p :: Node.NodeState -> IO ()
-p2p nodeState = do -- TODO: Take buffer size as argument, max size of blockchain
+p2p :: Node.NodeState -> Logger -> IO ()
+p2p nodeState logger = do -- TODO: Take buffer size as argument, max size of blockchain
   let (sender,receiver) = Node.nodeSender &&& Node.nodeReceiver $ nodeState
   void $ forkIO $ forever $ receiver >>= -- | Forever handle messages
     -- XXX forkIO here again?

--- a/src/Nanocoin/Network/P2P.hs
+++ b/src/Nanocoin/Network/P2P.hs
@@ -5,7 +5,7 @@ module Nanocoin.Network.P2P (
 ) where
 
 import Protolude hiding (msg)
-import Logger
+import Logger hiding (putText, print)
 
 import Control.Arrow ((&&&))
 

--- a/src/Nanocoin/Network/P2P.hs
+++ b/src/Nanocoin/Network/P2P.hs
@@ -6,6 +6,7 @@ module Nanocoin.Network.P2P (
 
 import Protolude hiding (msg)
 import Logger hiding (putText, print)
+import qualified System.Logger as Logger
 
 import Control.Arrow ((&&&))
 
@@ -26,7 +27,7 @@ import qualified Nanocoin.Network.RPC as RPC
 
 -- | Initializes a p2p node and returns a sender function so that
 -- the rpc server can broadcast messages to the p2p network
-p2p :: Node.NodeState -> Logger -> IO ()
+p2p :: Node.NodeState -> Logger.Logger -> IO ()
 p2p nodeState logger = do -- TODO: Take buffer size as argument, max size of blockchain
   let (sender,receiver) = Node.nodeSender &&& Node.nodeReceiver $ nodeState
   void $ forkIO $ forever $ receiver >>= -- | Forever handle messages

--- a/src/Nanocoin/Network/RPC.hs
+++ b/src/Nanocoin/Network/RPC.hs
@@ -3,8 +3,8 @@ module Nanocoin.Network.RPC (
   rpcServer
 ) where
 
-import Protolude hiding (get, intercalate)
-import Logger
+import Protolude hiding (get, intercalate, print)
+import Logger hiding (putText)
 
 import Data.Aeson hiding (json)
 import Data.Text (intercalate)

--- a/src/Nanocoin/Network/RPC.hs
+++ b/src/Nanocoin/Network/RPC.hs
@@ -3,8 +3,9 @@ module Nanocoin.Network.RPC (
   rpcServer
 ) where
 
-import Protolude hiding (get, intercalate, print)
-import Logger hiding (putText)
+import Protolude hiding (get, intercalate, print, putText)
+import Logger
+import qualified System.Logger as Logger
 
 import Data.Aeson hiding (json)
 import Data.Text (intercalate)
@@ -31,7 +32,7 @@ import qualified Nanocoin.Network.Message as Msg
 -------------------------------------------------------------------------------
 
 -- | Starts an RPC server for interaction via HTTP
-rpcServer :: NodeState -> Logger -> IO ()
+rpcServer :: NodeState -> Logger.Logger -> IO ()
 rpcServer nodeState logger = do
 
   let (Peer hostName p2pPort rpcPort) = nodeConfig nodeState
@@ -39,7 +40,7 @@ rpcServer nodeState logger = do
 
   scotty rpcPort $ do
 
-    defaultHandler $ putText . toS
+    defaultHandler $ Logger.err logger . Logger.msg
 
     --------------------------------------------------
     -- Queries

--- a/src/Nanocoin/Network/RPC.hs
+++ b/src/Nanocoin/Network/RPC.hs
@@ -63,7 +63,7 @@ rpcServer nodeState logger = do
     --------------------------------------------------
 
     get "/mineBlock" $ do
-      eBlock <- mineBlock nodeState
+      eBlock <- runReaderT (mineBlock nodeState) logger
       case eBlock of
         Left err -> text $ show err
         Right block -> json block

--- a/src/Nanocoin/Network/RPC.hs
+++ b/src/Nanocoin/Network/RPC.hs
@@ -4,6 +4,7 @@ module Nanocoin.Network.RPC (
 ) where
 
 import Protolude hiding (get, intercalate)
+import Logger
 
 import Data.Aeson hiding (json)
 import Data.Text (intercalate)
@@ -30,8 +31,8 @@ import qualified Nanocoin.Network.Message as Msg
 -------------------------------------------------------------------------------
 
 -- | Starts an RPC server for interaction via HTTP
-rpcServer :: NodeState -> IO ()
-rpcServer nodeState = do
+rpcServer :: NodeState -> Logger -> IO ()
+rpcServer nodeState logger = do
 
   let (Peer hostName p2pPort rpcPort) = nodeConfig nodeState
   let p2pSender = nodeSender nodeState


### PR DESCRIPTION
This adresses #16 

I tried to keep the impact on original source minimal – this is the reason for overridden `print` and `putText` in `Logger.hs`.

If I did something horrible, don't hesitate to point it out – I've been programming Haskell in a closet until now.