### PR TITLE
Reward toJSON had an extra space after string reward i.e. 'reward '

### DIFF
--- a/src/Nanocoin/Transaction.hs
+++ b/src/Nanocoin/Transaction.hs
@@ -221,7 +221,7 @@ instance ToJSON Reward where
                [ "x" .= (x :: Integer)
                , "y" .= (y :: Integer)
                ]
-           , "reward "    .= toJSON amnt
+           , "reward"    .= toJSON amnt
            ]
 
 instance ToJSON Transaction where


### PR DESCRIPTION
In the `toJSON` for `Reward`, the reward field had:

```"reward "    .= toJSON amnt```

I'd guess this should be ```"reward"    .= toJSON amnt```